### PR TITLE
Add user profile API endpoints and web frontend

### DIFF
--- a/src/Hermod.Api/Features/Profile/ProfileEndpoints.cs
+++ b/src/Hermod.Api/Features/Profile/ProfileEndpoints.cs
@@ -4,6 +4,7 @@ using Hermod.Data;
 using Hermod.Data.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
 using Wolverine.Http;
 
 namespace Hermod.Api.Features.Profile;
@@ -51,7 +52,7 @@ public static class ProfileEndpoints
 
     [Authorize]
     [WolverinePut("/api/profile")]
-    public static async Task<IResult> Put(UpdateProfileRequest request, ClaimsPrincipal user, HermodContext db)
+    public static async Task<IResult> Put(UpdateProfileRequest request, ClaimsPrincipal user, [FromServices] HermodContext db)
     {
         var userId = UserId.From(user.GetUserId()!.Value);
 
@@ -71,7 +72,15 @@ public static class ProfileEndpoints
         }
 
         if (request.BggUsername is not null)
+        {
+            if (request.BggUsername.Length > 200)
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["BggUsername"] = ["BGG username must be 200 characters or fewer."]
+                });
+
             profile.BggUsername = request.BggUsername;
+        }
 
         if (request.BggId is not null)
             profile.BggId = request.BggId;
@@ -79,12 +88,19 @@ public static class ProfileEndpoints
         if (request.SubscribeToPlays is not null)
             profile.SubscribeToPlays = request.SubscribeToPlays.Value;
 
+        // Re-fetch with includes so response contains groups
+        await db.SaveChangesAsync();
+        var updated = await db.UserProfiles
+            .Include(p => p.UserGroups)
+                .ThenInclude(ug => ug.Group)
+            .FirstAsync(p => p.Id == userId);
+
         return Results.Ok(new ProfileResponse(
-            profile.Id.Value,
-            profile.DisplayName,
-            profile.BggId,
-            profile.BggUsername,
-            profile.SubscribeToPlays,
-            []));
+            updated.Id.Value,
+            updated.DisplayName,
+            updated.BggId,
+            updated.BggUsername,
+            updated.SubscribeToPlays,
+            updated.UserGroups.Select(ug => new GroupSummary(ug.GroupId.Value, ug.Group.Name)).ToList()));
     }
 }

--- a/src/Hermod.Api/Features/Profile/ProfileEndpoints.cs
+++ b/src/Hermod.Api/Features/Profile/ProfileEndpoints.cs
@@ -1,0 +1,90 @@
+using System.Security.Claims;
+using Hermod.Api.Auth;
+using Hermod.Data;
+using Hermod.Data.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Wolverine.Http;
+
+namespace Hermod.Api.Features.Profile;
+
+public record GroupSummary(Guid GroupId, string Name);
+
+public record ProfileResponse(
+    Guid UserId,
+    string DisplayName,
+    int? BggId,
+    string? BggUsername,
+    bool SubscribeToPlays,
+    List<GroupSummary> Groups);
+
+public record UpdateProfileRequest(
+    string? DisplayName,
+    int? BggId,
+    string? BggUsername,
+    bool? SubscribeToPlays);
+
+public static class ProfileEndpoints
+{
+    [Authorize]
+    [WolverineGet("/api/profile")]
+    public static async Task<IResult> Get(ClaimsPrincipal user, HermodContext db)
+    {
+        var userId = UserId.From(user.GetUserId()!.Value);
+
+        var profile = await db.UserProfiles
+            .Include(p => p.UserGroups)
+                .ThenInclude(ug => ug.Group)
+            .FirstOrDefaultAsync(p => p.Id == userId);
+
+        if (profile is null)
+            return Results.NotFound();
+
+        return Results.Ok(new ProfileResponse(
+            profile.Id.Value,
+            profile.DisplayName,
+            profile.BggId,
+            profile.BggUsername,
+            profile.SubscribeToPlays,
+            profile.UserGroups.Select(ug => new GroupSummary(ug.GroupId.Value, ug.Group.Name)).ToList()));
+    }
+
+    [Authorize]
+    [WolverinePut("/api/profile")]
+    public static async Task<IResult> Put(UpdateProfileRequest request, ClaimsPrincipal user, HermodContext db)
+    {
+        var userId = UserId.From(user.GetUserId()!.Value);
+
+        var profile = await db.UserProfiles.FindAsync(userId);
+        if (profile is null)
+            return Results.NotFound();
+
+        if (request.DisplayName is not null)
+        {
+            if (request.DisplayName.Length > 200)
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["DisplayName"] = ["Display name must be 200 characters or fewer."]
+                });
+
+            profile.DisplayName = request.DisplayName;
+        }
+
+        if (request.BggUsername is not null)
+            profile.BggUsername = request.BggUsername;
+
+        if (request.BggId is not null)
+            profile.BggId = request.BggId;
+
+        if (request.SubscribeToPlays is not null)
+            profile.SubscribeToPlays = request.SubscribeToPlays.Value;
+
+        return Results.Ok(new ProfileResponse(
+            profile.Id.Value,
+            profile.DisplayName,
+            profile.BggId,
+            profile.BggUsername,
+            profile.SubscribeToPlays,
+            []));
+    }
+}

--- a/src/Hermod.Web/src/lib/__tests__/api.test.ts
+++ b/src/Hermod.Web/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchUser, fetchPlays, fetchGroups, uploadPlayFile, login } from '$lib/api';
+import { fetchUser, fetchPlays, fetchGroups, uploadPlayFile, login, fetchProfile, updateProfile } from '$lib/api';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -89,6 +89,69 @@ describe('uploadPlayFile', () => {
 		const result = await uploadPlayFile(file);
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error).toContain('File exceeds maximum size');
+	});
+});
+
+describe('fetchProfile', () => {
+	it('returns null on error', async () => {
+		mockFetch.mockResolvedValue({ ok: false, status: 404 });
+		const result = await fetchProfile();
+		expect(result).toBeNull();
+	});
+
+	it('returns profile on success', async () => {
+		const profile = {
+			userId: '123',
+			displayName: 'Test',
+			bggId: 42,
+			bggUsername: 'testbgg',
+			subscribeToPlays: true,
+			groups: [{ groupId: 'g1', name: 'Group 1' }]
+		};
+		mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(profile) });
+		const result = await fetchProfile();
+		expect(result).toEqual(profile);
+		expect(mockFetch).toHaveBeenCalledWith('/api/profile');
+	});
+});
+
+describe('updateProfile', () => {
+	it('returns profile on success', async () => {
+		const profile = {
+			userId: '123',
+			displayName: 'Updated',
+			bggId: null,
+			bggUsername: null,
+			subscribeToPlays: true,
+			groups: []
+		};
+		mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(profile) });
+		const result = await updateProfile({ displayName: 'Updated' });
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.profile.displayName).toBe('Updated');
+		expect(mockFetch).toHaveBeenCalledWith('/api/profile', {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ displayName: 'Updated' })
+		});
+	});
+
+	it('returns validation error on 400', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 400,
+			json: () => Promise.resolve({ errors: { DisplayName: ['Display name must be 200 characters or fewer.'] } })
+		});
+		const result = await updateProfile({ displayName: 'x'.repeat(201) });
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain('200 characters');
+	});
+
+	it('returns generic error on other failures', async () => {
+		mockFetch.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('Server error') });
+		const result = await updateProfile({ displayName: 'Test' });
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain('Server error');
 	});
 });
 

--- a/src/Hermod.Web/src/lib/__tests__/api.test.ts
+++ b/src/Hermod.Web/src/lib/__tests__/api.test.ts
@@ -137,10 +137,11 @@ describe('updateProfile', () => {
 	});
 
 	it('returns validation error on 400', async () => {
+		const body = { errors: { DisplayName: ['Display name must be 200 characters or fewer.'] } };
 		mockFetch.mockResolvedValue({
 			ok: false,
 			status: 400,
-			json: () => Promise.resolve({ errors: { DisplayName: ['Display name must be 200 characters or fewer.'] } })
+			text: () => Promise.resolve(JSON.stringify(body))
 		});
 		const result = await updateProfile({ displayName: 'x'.repeat(201) });
 		expect(result.ok).toBe(false);

--- a/src/Hermod.Web/src/lib/api.ts
+++ b/src/Hermod.Web/src/lib/api.ts
@@ -110,15 +110,17 @@ export async function updateProfile(data: UpdateProfileRequest): Promise<{ ok: t
 		body: JSON.stringify(data)
 	});
 	if (!res.ok) {
-		if (res.status === 400) {
-			const body = await res.json().catch(() => null);
-			const errors = body?.errors;
-			if (errors) {
-				const messages = Object.values(errors).flat() as string[];
-				return { ok: false, error: messages.join('. ') };
-			}
-		}
 		const text = await res.text();
+		if (res.status === 400 && text) {
+			try {
+				const body = JSON.parse(text);
+				const errors = body?.errors;
+				if (errors) {
+					const messages = Object.values(errors).flat() as string[];
+					return { ok: false, error: messages.join('. ') };
+				}
+			} catch { /* not JSON, fall through */ }
+		}
 		return { ok: false, error: text || `Update failed (${res.status})` };
 	}
 	return { ok: true, profile: await res.json() };

--- a/src/Hermod.Web/src/lib/api.ts
+++ b/src/Hermod.Web/src/lib/api.ts
@@ -32,6 +32,27 @@ export interface UploadResult {
 	playCount: number;
 }
 
+export interface ProfileGroupSummary {
+	groupId: string;
+	name: string;
+}
+
+export interface ProfileResponse {
+	userId: string;
+	displayName: string;
+	bggId: number | null;
+	bggUsername: string | null;
+	subscribeToPlays: boolean;
+	groups: ProfileGroupSummary[];
+}
+
+export interface UpdateProfileRequest {
+	displayName?: string;
+	bggId?: number;
+	bggUsername?: string;
+	subscribeToPlays?: boolean;
+}
+
 export async function fetchUser(): Promise<User | null> {
 	const res = await fetch('/auth/me');
 	if (!res.ok) return null;
@@ -74,6 +95,33 @@ export async function leaveGroup(groupId: string): Promise<{ status: 'left' | 'n
 	if (res.status === 404) return { status: 'not_found' };
 	if (res.status === 401) return { status: 'unauthorized' };
 	return { status: 'error' };
+}
+
+export async function fetchProfile(): Promise<ProfileResponse | null> {
+	const res = await fetch('/api/profile');
+	if (!res.ok) return null;
+	return res.json();
+}
+
+export async function updateProfile(data: UpdateProfileRequest): Promise<{ ok: true; profile: ProfileResponse } | { ok: false; error: string }> {
+	const res = await fetch('/api/profile', {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(data)
+	});
+	if (!res.ok) {
+		if (res.status === 400) {
+			const body = await res.json().catch(() => null);
+			const errors = body?.errors;
+			if (errors) {
+				const messages = Object.values(errors).flat() as string[];
+				return { ok: false, error: messages.join('. ') };
+			}
+		}
+		const text = await res.text();
+		return { ok: false, error: text || `Update failed (${res.status})` };
+	}
+	return { ok: true, profile: await res.json() };
 }
 
 export async function uploadPlayFile(file: File): Promise<{ ok: true; result: UploadResult } | { ok: false; error: string }> {

--- a/src/Hermod.Web/src/routes/+layout.svelte
+++ b/src/Hermod.Web/src/routes/+layout.svelte
@@ -36,6 +36,7 @@
 				<a href="/upload" class:active={$page.url.pathname === '/upload'}>Upload</a>
 				<a href="/plays" class:active={$page.url.pathname === '/plays'}>Plays</a>
 				<a href="/groups" class:active={$page.url.pathname === '/groups'}>Groups</a>
+				<a href="/profile" class:active={$page.url.pathname === '/profile'}>Profile</a>
 				<button class="btn-secondary sign-out" onclick={() => logout()}>Sign out</button>
 			</div>
 		{:else if !$loading}

--- a/src/Hermod.Web/src/routes/profile/+page.svelte
+++ b/src/Hermod.Web/src/routes/profile/+page.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { user, loading } from '$lib/stores/auth';
-	import { fetchProfile, updateProfile, login, type ProfileResponse } from '$lib/api';
+	import { fetchProfile, updateProfile, login, type ProfileResponse, type UpdateProfileRequest } from '$lib/api';
 
 	let profile = $state<ProfileResponse | null>(null);
 	let fetching = $state(true);
 
 	let displayName = $state('');
 	let bggUsername = $state('');
+	let subscribeToPlays = $state(false);
 	let saving = $state(false);
 	let successMessage = $state('');
 	let errorMessage = $state('');
@@ -21,6 +22,7 @@
 					if (p) {
 						displayName = p.displayName;
 						bggUsername = p.bggUsername ?? '';
+						subscribeToPlays = p.subscribeToPlays;
 					}
 					fetching = false;
 				});
@@ -39,9 +41,10 @@
 		}
 
 		saving = true;
-		const data: Record<string, string> = {};
+		const data: UpdateProfileRequest = {};
 		if (displayName !== profile?.displayName) data.displayName = displayName;
 		if (bggUsername !== (profile?.bggUsername ?? '')) data.bggUsername = bggUsername;
+		if (subscribeToPlays !== profile?.subscribeToPlays) data.subscribeToPlays = subscribeToPlays;
 
 		if (Object.keys(data).length === 0) {
 			successMessage = 'No changes to save.';
@@ -54,6 +57,7 @@
 
 		if (result.ok) {
 			profile = result.profile;
+			subscribeToPlays = result.profile.subscribeToPlays;
 			successMessage = 'Profile saved.';
 		} else {
 			errorMessage = result.error;
@@ -100,7 +104,24 @@
 				id="bggUsername"
 				type="text"
 				bind:value={bggUsername}
+				maxlength="200"
 			/>
+		</div>
+
+		{#if profile.bggId != null}
+			<div class="field">
+				<label>BGG ID</label>
+				<span class="readonly-value">{profile.bggId}</span>
+			</div>
+		{/if}
+
+		<div class="field checkbox-field">
+			<input
+				id="subscribeToPlays"
+				type="checkbox"
+				bind:checked={subscribeToPlays}
+			/>
+			<label for="subscribeToPlays">Subscribe to play notifications</label>
 		</div>
 
 		<button class="btn-primary" type="submit" disabled={saving}>
@@ -156,6 +177,25 @@
 	input:focus {
 		outline: none;
 		border-color: var(--color-primary);
+	}
+
+	.readonly-value {
+		color: var(--color-text-muted);
+	}
+
+	.checkbox-field {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.checkbox-field input[type='checkbox'] {
+		width: auto;
+	}
+
+	.checkbox-field label {
+		display: inline;
+		margin-bottom: 0;
 	}
 
 	.hint {

--- a/src/Hermod.Web/src/routes/profile/+page.svelte
+++ b/src/Hermod.Web/src/routes/profile/+page.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { user, loading } from '$lib/stores/auth';
+	import { fetchProfile, updateProfile, login, type ProfileResponse } from '$lib/api';
+
+	let profile = $state<ProfileResponse | null>(null);
+	let fetching = $state(true);
+
+	let displayName = $state('');
+	let bggUsername = $state('');
+	let saving = $state(false);
+	let successMessage = $state('');
+	let errorMessage = $state('');
+
+	onMount(() => {
+		const unsub = user.subscribe((u) => {
+			if (!$loading && !u) return;
+			if (u) {
+				fetchProfile().then((p) => {
+					profile = p;
+					if (p) {
+						displayName = p.displayName;
+						bggUsername = p.bggUsername ?? '';
+					}
+					fetching = false;
+				});
+			}
+		});
+		return unsub;
+	});
+
+	async function handleSave() {
+		successMessage = '';
+		errorMessage = '';
+
+		if (displayName.length > 200) {
+			errorMessage = 'Display name must be 200 characters or fewer.';
+			return;
+		}
+
+		saving = true;
+		const data: Record<string, string> = {};
+		if (displayName !== profile?.displayName) data.displayName = displayName;
+		if (bggUsername !== (profile?.bggUsername ?? '')) data.bggUsername = bggUsername;
+
+		if (Object.keys(data).length === 0) {
+			successMessage = 'No changes to save.';
+			saving = false;
+			return;
+		}
+
+		const result = await updateProfile(data);
+		saving = false;
+
+		if (result.ok) {
+			profile = result.profile;
+			successMessage = 'Profile saved.';
+		} else {
+			errorMessage = result.error;
+		}
+	}
+</script>
+
+<h1>Profile</h1>
+
+{#if $loading || fetching}
+	<p>Loading...</p>
+{:else if !$user}
+	<div class="card">
+		<p>Sign in to view your profile.</p>
+		<button class="btn-primary" onclick={() => login('/profile')}>Sign in with Discord</button>
+	</div>
+{:else if !profile}
+	<div class="card">
+		<p>No profile found. Join a group to create your profile.</p>
+	</div>
+{:else}
+	{#if successMessage}
+		<div class="alert alert-success">{successMessage}</div>
+	{/if}
+	{#if errorMessage}
+		<div class="alert alert-error">{errorMessage}</div>
+	{/if}
+
+	<form class="card" onsubmit={(e) => { e.preventDefault(); handleSave(); }}>
+		<div class="field">
+			<label for="displayName">Display name</label>
+			<input
+				id="displayName"
+				type="text"
+				bind:value={displayName}
+				maxlength="200"
+			/>
+			<span class="hint">{displayName.length}/200</span>
+		</div>
+
+		<div class="field">
+			<label for="bggUsername">BGG username</label>
+			<input
+				id="bggUsername"
+				type="text"
+				bind:value={bggUsername}
+			/>
+		</div>
+
+		<button class="btn-primary" type="submit" disabled={saving}>
+			{saving ? 'Saving...' : 'Save'}
+		</button>
+	</form>
+
+	<section class="card groups-section">
+		<h2>Groups</h2>
+		{#if profile.groups.length === 0}
+			<p class="muted">You are not a member of any groups.</p>
+		{:else}
+			<ul class="group-list">
+				{#each profile.groups as group}
+					<li>{group.name}</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+{/if}
+
+<style>
+	h1 {
+		margin-bottom: 1.5rem;
+	}
+
+	form {
+		margin-bottom: 1.5rem;
+	}
+
+	.field {
+		margin-bottom: 1rem;
+	}
+
+	label {
+		display: block;
+		font-size: 0.9rem;
+		margin-bottom: 0.25rem;
+		color: var(--color-text-muted);
+	}
+
+	input {
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border-radius: var(--radius);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg);
+		color: var(--color-text);
+		font-size: 1rem;
+		font-family: inherit;
+	}
+
+	input:focus {
+		outline: none;
+		border-color: var(--color-primary);
+	}
+
+	.hint {
+		display: block;
+		font-size: 0.75rem;
+		color: var(--color-text-muted);
+		margin-top: 0.25rem;
+		text-align: right;
+	}
+
+	.groups-section {
+		margin-bottom: 1.5rem;
+	}
+
+	h2 {
+		font-size: 1.1rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.muted {
+		color: var(--color-text-muted);
+	}
+
+	.group-list {
+		list-style: none;
+	}
+
+	.group-list li {
+		padding: 0.5rem 0;
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.group-list li:last-child {
+		border-bottom: none;
+	}
+</style>

--- a/tests/Hermod.Api.Tests/Endpoints/ProfileEndpointTests.cs
+++ b/tests/Hermod.Api.Tests/Endpoints/ProfileEndpointTests.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Net.Http.Json;
+using Hermod.Data;
+using Hermod.Data.Entities;
+using Microsoft.Extensions.DependencyInjection;
+using TUnit.Core;
+
+namespace Hermod.Api.Tests.Endpoints;
+
+public class ProfileEndpointTests
+{
+    [ClassDataSource<ApiFixture>(Shared = SharedType.PerTestSession)]
+    public required ApiFixture Api { get; init; }
+
+    private async Task<(Guid userId, Guid groupId)> SeedProfileWithGroup()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        await using var scope = Api.CreateDbScope();
+        var db = scope.ServiceProvider.GetRequiredService<HermodContext>();
+
+        var group = new GroupEntity { Id = GroupId.From(groupId), Name = "Profile Test Group" };
+        db.Groups.Add(group);
+
+        var profile = new UserProfileEntity
+        {
+            Id = UserId.From(userId),
+            DisplayName = "TestProfile",
+            BggUsername = "testbgg",
+            BggId = 42,
+            SubscribeToPlays = true
+        };
+        db.UserProfiles.Add(profile);
+        await db.SaveChangesAsync();
+
+        db.UserGroups.Add(new UserGroupEntity
+        {
+            UserId = UserId.From(userId),
+            GroupId = GroupId.From(groupId),
+            Role = GroupRole.Member,
+        });
+        await db.SaveChangesAsync();
+
+        return (userId, groupId);
+    }
+
+    // --- GET /api/profile ---
+
+    [Test]
+    public async Task GetProfile_ReturnsProfileWithGroupList()
+    {
+        var (userId, groupId) = await SeedProfileWithGroup();
+        var client = Api.CreateAuthenticatedClient(userId);
+
+        var response = await client.GetAsync("/api/profile");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ProfileResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.UserId).IsEqualTo(userId);
+        await Assert.That(body.DisplayName).IsEqualTo("TestProfile");
+        await Assert.That(body.BggUsername).IsEqualTo("testbgg");
+        await Assert.That(body.BggId).IsEqualTo(42);
+        await Assert.That(body.SubscribeToPlays).IsTrue();
+        await Assert.That(body.Groups.Count).IsEqualTo(1);
+        await Assert.That(body.Groups[0].GroupId).IsEqualTo(groupId);
+        await Assert.That(body.Groups[0].Name).IsEqualTo("Profile Test Group");
+    }
+
+    [Test]
+    public async Task GetProfile_NoProfile_Returns404()
+    {
+        var client = Api.CreateAuthenticatedClient(Guid.NewGuid());
+
+        var response = await client.GetAsync("/api/profile");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task GetProfile_Anonymous_ReturnsUnauthorized()
+    {
+        var client = Api.CreateAnonymousClient();
+
+        var response = await client.GetAsync("/api/profile");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    // --- PUT /api/profile ---
+
+    [Test]
+    public async Task PutProfile_UpdateDisplayName_ReturnsUpdated()
+    {
+        var (userId, _) = await SeedProfileWithGroup();
+        var client = Api.CreateAuthenticatedClient(userId);
+
+        var response = await client.PutAsJsonAsync("/api/profile",
+            new { DisplayName = "NewName" });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ProfileResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.DisplayName).IsEqualTo("NewName");
+        // Other fields unchanged
+        await Assert.That(body.BggUsername).IsEqualTo("testbgg");
+        await Assert.That(body.BggId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task PutProfile_UpdateBggUsername_ReturnsUpdated()
+    {
+        var userId = Guid.NewGuid();
+        await using var scope = Api.CreateDbScope();
+        var db = scope.ServiceProvider.GetRequiredService<HermodContext>();
+        db.UserProfiles.Add(new UserProfileEntity
+        {
+            Id = UserId.From(userId),
+            DisplayName = "BggUser",
+            BggUsername = "oldbgg"
+        });
+        await db.SaveChangesAsync();
+
+        var client = Api.CreateAuthenticatedClient(userId);
+
+        var response = await client.PutAsJsonAsync("/api/profile",
+            new { BggUsername = "newbgg" });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ProfileResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.BggUsername).IsEqualTo("newbgg");
+        await Assert.That(body.DisplayName).IsEqualTo("BggUser");
+    }
+
+    [Test]
+    public async Task PutProfile_UpdateSubscribeToPlays_ReturnsUpdated()
+    {
+        var userId = Guid.NewGuid();
+        await using var scope = Api.CreateDbScope();
+        var db = scope.ServiceProvider.GetRequiredService<HermodContext>();
+        db.UserProfiles.Add(new UserProfileEntity
+        {
+            Id = UserId.From(userId),
+            DisplayName = "SubUser",
+            SubscribeToPlays = true
+        });
+        await db.SaveChangesAsync();
+
+        var client = Api.CreateAuthenticatedClient(userId);
+
+        var response = await client.PutAsJsonAsync("/api/profile",
+            new { SubscribeToPlays = false });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ProfileResponse>();
+        await Assert.That(body).IsNotNull();
+        await Assert.That(body!.SubscribeToPlays).IsFalse();
+    }
+
+    [Test]
+    public async Task PutProfile_DisplayNameTooLong_ReturnsValidationProblem()
+    {
+        var userId = Guid.NewGuid();
+        await using var scope = Api.CreateDbScope();
+        var db = scope.ServiceProvider.GetRequiredService<HermodContext>();
+        db.UserProfiles.Add(new UserProfileEntity
+        {
+            Id = UserId.From(userId),
+            DisplayName = "ValidUser"
+        });
+        await db.SaveChangesAsync();
+
+        var client = Api.CreateAuthenticatedClient(userId);
+
+        var longName = new string('a', 201);
+        var response = await client.PutAsJsonAsync("/api/profile",
+            new { DisplayName = longName });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task PutProfile_NoProfile_Returns404()
+    {
+        var client = Api.CreateAuthenticatedClient(Guid.NewGuid());
+
+        var response = await client.PutAsJsonAsync("/api/profile",
+            new { DisplayName = "DoesNotExist" });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task PutProfile_Anonymous_ReturnsUnauthorized()
+    {
+        var client = Api.CreateAnonymousClient();
+
+        var response = await client.PutAsJsonAsync("/api/profile",
+            new { DisplayName = "Nope" });
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    private record GroupSummary(Guid GroupId, string Name);
+
+    private record ProfileResponse(
+        Guid UserId,
+        string DisplayName,
+        int? BggId,
+        string? BggUsername,
+        bool SubscribeToPlays,
+        List<GroupSummary> Groups);
+}


### PR DESCRIPTION
## Summary

- **GET /api/profile** and **PUT /api/profile** endpoints for authenticated users to read and update their profile (display name, BGG username, BGG ID, subscribe-to-plays preference) with partial update semantics and validation
- **/profile** SvelteKit page with editable form fields, save/validation feedback, and read-only group list
- **Profile nav link** visible only when authenticated
- **API client functions** (`fetchProfile`, `updateProfile`) with error handling
- **9 TUnit endpoint tests** covering all API acceptance criteria
- **5 Vitest unit tests** for the new API client functions

## Linked Issues

Closes #38
Closes #39

## Test plan

- [x] `dotnet build Hermod.slnx` succeeds
- [x] All 9 profile API endpoint tests pass (GET returns profile with groups, GET 404 for missing profile, PUT updates individual fields, PUT validates display name length, PUT 404 for missing profile, auth guards on both endpoints)
- [x] All 19 frontend unit tests pass (including 5 new profile API tests)
- [x] All pre-existing API tests (97) pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)