### PR TITLE
feat: semver image tags via Release Please

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -54,3 +54,4 @@ jobs:
         env:
           Parameters__registry-endpoint: ghcr.io
           Parameters__registry-repository: ${{ github.repository_owner }}
+          Parameters__registry-tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -43,7 +43,7 @@ jobs:
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "tag=vNext" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push images

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches: [vNext]
+    branches: [main]
 
 permissions:
   contents: write
@@ -15,4 +15,3 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          target-branch: vNext

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [vNext]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: simple
+          target-branch: vNext

--- a/src/Hermod.AppHost/AppHost.cs
+++ b/src/Hermod.AppHost/AppHost.cs
@@ -1,15 +1,19 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 #pragma warning disable ASPIRECOMPUTE003 // Container registry APIs are experimental
+#pragma warning disable ASPIREPIPELINES003 // Pipeline APIs are experimental
 var registryEndpoint = builder.AddParameter("registry-endpoint", "ghcr.io", publishValueAsDefault: true);
 var registryRepository = builder.AddParameter("registry-repository", "theiam79", publishValueAsDefault: true);
+var registryTag = builder.Configuration["Parameters:registry-tag"] ?? "latest";
 var registry = builder.AddContainerRegistry("ghcr", registryEndpoint, registryRepository);
 
 var api = builder.AddProject<Projects.Hermod_Api>("hermod-api")
-    .WithContainerRegistry(registry);
+    .WithContainerRegistry(registry)
+    .WithRemoteImageTag(registryTag);
 
 var bot = builder.AddProject<Projects.Hermod_Bot>("hermod-bot")
-    .WithContainerRegistry(registry);
+    .WithContainerRegistry(registry)
+    .WithRemoteImageTag(registryTag);
 
 // Run mode: Aspire provisions containers and manages secrets from user secrets.
 // Publish mode: K8s injects connection strings and secrets as env vars at deploy time.
@@ -72,7 +76,8 @@ if (builder.ExecutionContext.IsRunMode)
         .WithHostHttpsPort(8443)
         .WithConfiguration(yarp => yarp.AddRoute("{**catch-all}", frontend))
         .WithExternalHttpEndpoints()
-        .WithContainerRegistry(registry);
+        .WithContainerRegistry(registry)
+        .WithRemoteImageTag(registryTag);
 
     if (useTunnel)
     {
@@ -103,8 +108,10 @@ else
         })
         .WithExternalHttpEndpoints()
         .PublishWithStaticFiles(frontend)
-        .WithContainerRegistry(registry);
+        .WithContainerRegistry(registry)
+        .WithRemoteImageTag(registryTag);
 }
+#pragma warning restore ASPIREPIPELINES003
 #pragma warning restore ASPIRECOMPUTE003
 
 builder.Build().Run();


### PR DESCRIPTION
## Summary

- Adds **Release Please** workflow on `main` to auto-create release PRs from conventional commits and tag stable releases
- Adds `registry-tag` config parameter to AppHost (defaults to `latest`), applied via `WithRemoteImageTag()` on all container-registry resources
- vNext branch pushes build images tagged `vNext` (prerelease); `v*` tag pushes build images with semver (stable)

## Flow

```
vNext push → images tagged "vNext" (prerelease, rolling)
         ↓
merge vNext → main → Release Please creates release PR (bumps version)
         ↓
merge release PR → Release Please creates v1.2.0 tag + GitHub release
         ↓
v1.2.0 tag push → images tagged "v1.2.0" (stable)
```

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release-please.yml` | New workflow on `main`: `release-type: simple` |
| `.github/workflows/build-images.yml` | Branch pushes tag as `vNext`, tag pushes use `github.ref_name`; passes `Parameters__registry-tag` |
| `src/Hermod.AppHost/AppHost.cs` | Reads `Parameters:registry-tag` from config, calls `.WithRemoteImageTag()` on api, bot, and gateway (both run/publish modes) |

## Test plan

- [x] All 161 tests pass
- [x] AppHost builds cleanly
- [ ] After merge to vNext: verify images push as `vNext` tag
- [ ] After merge vNext → main: verify Release Please creates first release PR
- [ ] After first release: verify tagged build pushes images with version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)