### PR TITLE
fix: correct service worker for PWA install on Android

### DIFF
--- a/src/Hermod.Web/src/service-worker.ts
+++ b/src/Hermod.Web/src/service-worker.ts
@@ -8,7 +8,7 @@ import { build, files, version } from '$service-worker';
 const APP_CACHE = `app-${version}`;
 const SHARE_CACHE = 'share-target';
 
-const PRECACHE_ASSETS = [...build, ...files];
+const PRECACHE_ASSETS = [...build, ...files, '/index.html'];
 
 self.addEventListener('install', (event) => {
 	event.waitUntil(
@@ -16,6 +16,10 @@ self.addEventListener('install', (event) => {
 			.open(APP_CACHE)
 			.then((cache) => cache.addAll(PRECACHE_ASSETS))
 			.then(() => self.skipWaiting())
+			.catch((err) => {
+				console.error('SW install failed:', err);
+				throw err;
+			})
 	);
 });
 
@@ -57,7 +61,7 @@ self.addEventListener('fetch', (event) => {
 	if (event.request.mode === 'navigate') {
 		event.respondWith(
 			fetch(event.request).catch(() =>
-				caches.match('/200.html').then((cached) => cached || caches.match('/'))
+				caches.match('/index.html').then((cached) => cached || caches.match('/'))
 			).then((response) => response || new Response('Offline', { status: 503 }))
 		);
 		return;


### PR DESCRIPTION
## Summary

- Fix service worker offline fallback referencing non-existent `/200.html` (should be `/index.html` per adapter-static config)
- Precache `/index.html` SPA shell so offline navigation actually works
- Add error logging to SW install event for diagnosability

## Context

Closes #51 — PWA installation was failing on Android. The service worker had a mismatch between the fallback file it referenced (`/200.html`) and what the build actually generates (`index.html`). The SPA shell was also never precached, breaking offline navigation entirely.

## Test plan

- [ ] Deploy and verify SW activates (Chrome DevTools > Application > Service Workers)
- [ ] Confirm PWA install prompt appears on Android
- [ ] Run Lighthouse PWA audit on deployed site
- [ ] Test offline navigation falls back to SPA shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)