### PR TITLE
feat: add OTLP resource attributes for production observability

### DIFF
--- a/src/Hermod.ServiceDefaults/Extensions.cs
+++ b/src/Hermod.ServiceDefaults/Extensions.cs
@@ -4,8 +4,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ServiceDiscovery;
+using System.Reflection;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
@@ -53,6 +55,18 @@ public static class Extensions
         });
 
         builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resource =>
+            {
+                var version = Assembly.GetEntryAssembly()
+                    ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                    ?? "unknown";
+
+                resource.AddAttributes(new KeyValuePair<string, object>[]
+                {
+                    new("service.version", version),
+                    new("deployment.environment", builder.Environment.EnvironmentName.ToLowerInvariant()),
+                });
+            })
             .WithMetrics(metrics =>
             {
                 metrics.AddAspNetCoreInstrumentation()


### PR DESCRIPTION
## Summary

- Adds `service.version` and `deployment.environment` resource attributes to the OpenTelemetry configuration in ServiceDefaults
- `service.version` is read from the entry assembly's `InformationalVersion` (populated by `<Version>` in csproj or Release Please)
- `deployment.environment` is derived from `ASPNETCORE_ENVIRONMENT` / `DOTNET_ENVIRONMENT`, lowercased

These attributes allow filtering traces, metrics, and logs by service version and environment in Grafana.

## Infrastructure

The corresponding infrastructure changes (OTel Collector, Tempo, Aspire Dashboard, Grafana datasource, Prometheus remote write, hermod env vars) are tracked in theiam79/home-ops#130.

No app-side changes are needed beyond this PR — the existing `UseOtlpExporter()` + `OTEL_EXPORTER_OTLP_ENDPOINT` pattern handles both dev (Aspire Dashboard) and prod (OTel Collector) transparently.

Closes #50

## Test plan

- [x] Solution builds cleanly
- [ ] Verify resource attributes appear in local Aspire Dashboard traces/logs
- [ ] Deploy infrastructure from home-ops#130 and confirm end-to-end telemetry flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)