### PR TITLE
feat: drop Wolverine durability agent traces entirely

### DIFF
--- a/src/Hermod.ServiceDefaults/Extensions.cs
+++ b/src/Hermod.ServiceDefaults/Extensions.cs
@@ -76,7 +76,7 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                tracing.SetSampler(new SelectiveSampler(wolverineRatio: 0.05))
+                tracing.SetSampler(new SelectiveSampler())
                     .AddSource(builder.Environment.ApplicationName)
                     .AddSource("Wolverine")
                     .AddSource("NATS.Net")

--- a/src/Hermod.ServiceDefaults/SelectiveSampler.cs
+++ b/src/Hermod.ServiceDefaults/SelectiveSampler.cs
@@ -3,20 +3,17 @@ using OpenTelemetry.Trace;
 namespace Microsoft.Extensions.Hosting;
 
 /// <summary>
-/// Samples Wolverine durability agent traces at a reduced rate
+/// Drops Wolverine durability agent traces entirely (internal bookkeeping noise)
 /// while keeping all other traces (HTTP requests, application handlers, etc.) at 100%.
 /// </summary>
-public sealed class SelectiveSampler(double wolverineRatio = 0.05) : Sampler
+public sealed class SelectiveSampler : Sampler
 {
-    private readonly Sampler _wolverineSampler =
-        new ParentBasedSampler(new TraceIdRatioBasedSampler(wolverineRatio));
-    private readonly Sampler _defaultSampler =
-        new ParentBasedSampler(new AlwaysOnSampler());
+    private static readonly SamplingResult Drop = new(SamplingDecision.Drop);
+    private readonly Sampler _defaultSampler = new ParentBasedSampler(new AlwaysOnSampler());
 
     public override SamplingResult ShouldSample(in SamplingParameters parameters)
     {
-        var sampler = IsWolverineInternal(parameters) ? _wolverineSampler : _defaultSampler;
-        return sampler.ShouldSample(parameters);
+        return IsWolverineInternal(parameters) ? Drop : _defaultSampler.ShouldSample(parameters);
     }
 
     private static bool IsWolverineInternal(in SamplingParameters parameters)


### PR DESCRIPTION
## Summary

- Changes `SelectiveSampler` from 5% sampling to fully dropping Wolverine durability agent traces
- These are internal bookkeeping spans (polling `wolverine.*` tables, `pg_try_advisory_xact_lock`) with no diagnostic value
- All other traces (HTTP requests, message handlers, NATS, etc.) remain at 100%

Closes #54

## Test plan

- [x] Solution builds cleanly
- [ ] Verify Wolverine durability spans no longer appear in Aspire Dashboard / Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)