### PR TITLE
fix: prevent CDN caching of service worker and manifest

### DIFF
--- a/src/Hermod.Api/Program.cs
+++ b/src/Hermod.Api/Program.cs
@@ -148,7 +148,20 @@ if (app.Environment.IsDevelopment())
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.UseStaticFiles();
+app.UseStaticFiles(new StaticFileOptions
+{
+    OnPrepareResponse = ctx =>
+    {
+        // Service worker and manifest must never be cached by CDNs/proxies —
+        // stale versions reference build-hashed asset URLs that no longer exist
+        // after a new deployment, causing cache.addAll() to fail silently.
+        var path = ctx.File.Name;
+        if (path is "service-worker.js" or "manifest.json")
+        {
+            ctx.Context.Response.Headers[Microsoft.Net.Http.Headers.HeaderNames.CacheControl] = "no-cache";
+        }
+    }
+});
 
 app.MapWolverineEndpoints(opts =>
     opts.ConfigureEndpoints(e => e.DisableAntiforgery()));


### PR DESCRIPTION
## Summary

- Set `Cache-Control: no-cache` on `service-worker.js` and `manifest.json` responses so CDNs (Cloudflare) always revalidate

## Root cause

Cloudflare was caching the service worker (`max-age=14400`, `cf-cache-status: HIT`). After a new build deployed with new content-hashed asset filenames, the stale SW tried to `cache.addAll()` URLs from the old build — which returned 404. The silent failure meant the SW never activated, so Chrome never showed the PWA install prompt on Android.

Verified by comparing deployed assets:
- HTML loads `app.BFw1Kvax.js` (current build)
- Cached SW precaches `app.DaE8DeqT.js` (old build) → **404**

## Test plan

- [ ] Deploy and verify `curl -sI https://beta.hermod.dev/service-worker.js` shows `cache-control: no-cache`
- [ ] Confirm `cf-cache-status` is no longer `HIT` for service-worker.js
- [ ] Verify PWA install prompt appears on Android Chrome
- [ ] Purge Cloudflare cache for service-worker.js after deploy to force immediate effect

Ref #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)