### PR TITLE
fix: remove unsupported SVG icon from PWA manifest

### DIFF
--- a/src/Hermod.Web/static/manifest.json
+++ b/src/Hermod.Web/static/manifest.json
@@ -28,11 +28,6 @@
 			"sizes": "512x512",
 			"type": "image/png",
 			"purpose": "maskable"
-		},
-		{
-			"src": "/icons/icon-192.svg",
-			"sizes": "any",
-			"type": "image/svg+xml"
 		}
 	],
 	"screenshots": [


### PR DESCRIPTION
## Summary

- Remove the SVG icon entry from `manifest.json` — Chrome doesn't support SVG icons in PWA manifests and logs a warning that blocks installation

## Context

Ref #51 — After fixing the screenshots and cache-control issues, Chrome DevTools still showed a warning about failing to load `/icons/icon-192.svg` from the manifest. Chrome only supports raster (PNG) icons for PWA installation. The existing 192x192 and 512x512 PNG icons are sufficient.

## Test plan

- [ ] Verify no icon warnings in Chrome DevTools > Application > Manifest
- [ ] Confirm PWA install prompt appears on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)