### PR TITLE
fix: improve PWA install reliability and reduce precache size

### DIFF
--- a/src/Hermod.Web/src/app.d.ts
+++ b/src/Hermod.Web/src/app.d.ts
@@ -17,6 +17,10 @@ declare global {
 	interface WindowEventMap {
 		beforeinstallprompt: BeforeInstallPromptEvent;
 	}
+
+	interface Window {
+		deferredInstallPrompt?: BeforeInstallPromptEvent;
+	}
 }
 
 export {};

--- a/src/Hermod.Web/src/app.html
+++ b/src/Hermod.Web/src/app.html
@@ -13,6 +13,12 @@
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">
+		<script>
+			window.addEventListener('beforeinstallprompt', function (e) {
+				e.preventDefault();
+				window.deferredInstallPrompt = e;
+			});
+		</script>
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/Hermod.Web/src/lib/InstallPrompt.svelte
+++ b/src/Hermod.Web/src/lib/InstallPrompt.svelte
@@ -12,6 +12,11 @@
 			return;
 		}
 
+		// Check for event captured early in app.html before Svelte mounted
+		if (window.deferredInstallPrompt) {
+			deferredPrompt = window.deferredInstallPrompt;
+		}
+
 		const handler = (e: Event) => {
 			e.preventDefault();
 			deferredPrompt = e as BeforeInstallPromptEvent;

--- a/src/Hermod.Web/static/manifest.json
+++ b/src/Hermod.Web/static/manifest.json
@@ -2,6 +2,7 @@
 	"name": "Hermod",
 	"short_name": "Hermod",
 	"description": "Share your board game plays from BGStats",
+	"id": "/",
 	"start_url": "/",
 	"display": "standalone",
 	"background_color": "#1d2323",

--- a/src/Hermod.Web/svelte.config.js
+++ b/src/Hermod.Web/svelte.config.js
@@ -7,7 +7,10 @@ const config = {
 			pages: 'dist',
 			assets: 'dist',
 			fallback: 'index.html'
-		})
+		}),
+		serviceWorker: {
+			files: (filepath) => !filepath.startsWith('/screenshots')
+		}
 	}
 };
 


### PR DESCRIPTION
## Summary
- **Early `beforeinstallprompt` capture** in `app.html` — Chrome may fire this event before Svelte components mount via `onMount`, causing the install prompt to never appear. The event is now stashed on `window.deferredInstallPrompt` and read by `InstallPrompt.svelte` on mount.
- **Add `"id": "/"` to manifest** — best practice for stable PWA identity across URL changes
- **Filter screenshots from SW precache** — `svelte.config.js` now excludes `/screenshots` from the service worker `files` list, reducing unnecessary precache size

Closes #51

## Test plan
- [ ] Verify `npm run build` succeeds in `src/Hermod.Web`
- [ ] On Android Chrome, confirm install prompt banner appears after engagement heuristic is met
- [ ] Verify screenshots are NOT listed in the service worker's precache manifest (inspect built `service-worker.js`)
- [ ] Confirm PWA still works offline after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)