### PR TITLE
Fix guild deactivation race during bot startup; add manual activate/deactivate

### DIFF
--- a/src/Hermod.Bot/Modules/SharingModule.cs
+++ b/src/Hermod.Bot/Modules/SharingModule.cs
@@ -103,6 +103,7 @@ public class SharingModule(IServiceScopeFactory scopeFactory) : ApplicationComma
 
         if (mapping is null)
         {
+            // Slash commands execute in-guild so the cache hit is near-certain; fallback is just defensive
             var guildName = Context.Client.Cache.Guilds.GetValueOrDefault(guildId.Value)?.Name ?? "Unknown Server";
             await registrationService.RegisterGuildAsync(guildId.Value, guildName);
             await FollowupAsync(new() { Content = "Server has been registered and activated.", Flags = MessageFlags.Ephemeral });

--- a/src/Hermod.Bot/Modules/SharingModule.cs
+++ b/src/Hermod.Bot/Modules/SharingModule.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Hermod.Bot.Data;
+using Hermod.Bot.Services;
 using Hermod.Messages;
 using Microsoft.EntityFrameworkCore;
 using NetCord;
@@ -79,6 +80,72 @@ public class SharingModule(IServiceScopeFactory scopeFactory) : ApplicationComma
         await bus.PublishAsync(new UpdateGroupSharing(mapping.GroupId, false));
 
         await FollowupAsync(new() { Content = "Play sharing has been disabled.", Flags = MessageFlags.Ephemeral });
+    }
+
+    [SubSlashCommand("activate", "Activate this server's Hermod registration")]
+    public async Task ActivateAsync()
+    {
+        await RespondAsync(InteractionCallback.DeferredMessage(MessageFlags.Ephemeral));
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
+        var registrationService = scope.ServiceProvider.GetRequiredService<GuildRegistrationService>();
+
+        var guildId = Context.Interaction.GuildId;
+        if (guildId is null)
+        {
+            await FollowupAsync(new() { Content = "This command can only be used in a server.", Flags = MessageFlags.Ephemeral });
+            return;
+        }
+
+        var mapping = await db.GuildMappings
+            .FirstOrDefaultAsync(m => m.DiscordGuildId == guildId.Value);
+
+        if (mapping is null)
+        {
+            var guildName = Context.Client.Cache.Guilds.GetValueOrDefault(guildId.Value)?.Name ?? "Unknown Server";
+            await registrationService.RegisterGuildAsync(guildId.Value, guildName);
+            await FollowupAsync(new() { Content = "Server has been registered and activated.", Flags = MessageFlags.Ephemeral });
+            return;
+        }
+
+        if (mapping.IsActive)
+        {
+            await FollowupAsync(new() { Content = "This server is already active.", Flags = MessageFlags.Ephemeral });
+            return;
+        }
+
+        await registrationService.ReactivateAsync(mapping);
+        await FollowupAsync(new() { Content = "Server has been reactivated.", Flags = MessageFlags.Ephemeral });
+    }
+
+    [SubSlashCommand("deactivate", "Deactivate this server's Hermod registration")]
+    public async Task DeactivateAsync()
+    {
+        await RespondAsync(InteractionCallback.DeferredMessage(MessageFlags.Ephemeral));
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
+        var registrationService = scope.ServiceProvider.GetRequiredService<GuildRegistrationService>();
+
+        var guildId = Context.Interaction.GuildId;
+        if (guildId is null)
+        {
+            await FollowupAsync(new() { Content = "This command can only be used in a server.", Flags = MessageFlags.Ephemeral });
+            return;
+        }
+
+        var mapping = await db.GuildMappings
+            .FirstOrDefaultAsync(m => m.DiscordGuildId == guildId.Value && m.IsActive);
+
+        if (mapping is null)
+        {
+            await FollowupAsync(new() { Content = "This server is not currently active.", Flags = MessageFlags.Ephemeral });
+            return;
+        }
+
+        await registrationService.DeactivateAsync(mapping);
+        await FollowupAsync(new() { Content = "Server has been deactivated. Use `/sharing activate` to re-enable.", Flags = MessageFlags.Ephemeral });
     }
 
     [SubSlashCommand("unclaim", "Remove a player claim for a user")]

--- a/src/Hermod.Bot/Program.cs
+++ b/src/Hermod.Bot/Program.cs
@@ -1,4 +1,5 @@
 using Hermod.Bot.Data;
+using Hermod.Bot.Services;
 using Hermod.Messages;
 using Microsoft.EntityFrameworkCore;
 using NetCord;
@@ -21,6 +22,7 @@ var natsUrl = builder.Configuration.GetConnectionString("nats")
 var isTesting = builder.Configuration["Testing:Enabled"] is "true";
 
 builder.AddNpgsqlDbContext<BotDbContext>("bot-db");
+builder.Services.AddScoped<GuildRegistrationService>();
 
 if (!isTesting)
 {

--- a/src/Hermod.Bot/Services/GuildEventService.cs
+++ b/src/Hermod.Bot/Services/GuildEventService.cs
@@ -1,10 +1,8 @@
 using Hermod.Bot.Data;
-using Hermod.Messages;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NetCord.Gateway;
 using NetCord.Hosting.Gateway;
-using Wolverine;
 
 namespace Hermod.Bot.Services;
 
@@ -21,7 +19,7 @@ public class GuildCreateHandler(
         {
             await using var scope = scopeFactory.CreateAsyncScope();
             var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
-            var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+            var registrationService = scope.ServiceProvider.GetRequiredService<GuildRegistrationService>();
 
             var existing = await db.GuildMappings
                 .FirstOrDefaultAsync(m => m.DiscordGuildId == guild.Id);
@@ -30,59 +28,18 @@ public class GuildCreateHandler(
             {
                 if (!existing.IsActive)
                 {
-                    existing.IsActive = true;
-                    existing.DeactivatedAt = null;
-                    await db.SaveChangesAsync();
-
-                    if (existing.PostChannelId is not null)
-                    {
-                        await bus.PublishAsync(new UpdateGroupSharing(existing.GroupId, true));
-                    }
-
-                    logger.LogInformation("Reactivated guild mapping for {GuildName} ({GuildId})", guild.Name, guild.Id);
+                    await registrationService.ReactivateAsync(existing);
                 }
 
                 return;
             }
 
-            await RegisterNewGuildAsync(guild.Id, guild.Name, db, bus);
+            await registrationService.RegisterGuildAsync(guild.Id, guild.Name);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling GuildCreate for {GuildName} ({GuildId})", guild.Name, guild.Id);
         }
-    }
-
-    private async Task RegisterNewGuildAsync(ulong discordGuildId, string guildName, BotDbContext db, IMessageBus bus)
-    {
-        logger.LogInformation("Registering guild {GuildName} ({GuildId}) via NATS...", guildName, discordGuildId);
-        var registered = await bus.InvokeAsync<CommunityRegistered>(
-            new RegisterCommunity(Providers.Discord, discordGuildId.ToString(), guildName),
-            timeout: TimeSpan.FromSeconds(10));
-
-        var existing = await db.GuildMappings
-            .FirstOrDefaultAsync(m => m.DiscordGuildId == discordGuildId);
-
-        if (existing is not null)
-        {
-            existing.GroupId = registered.GroupId;
-            existing.IsActive = true;
-            existing.DeactivatedAt = null;
-        }
-        else
-        {
-            db.GuildMappings.Add(new GuildMappingEntity
-            {
-                Id = Guid.NewGuid(),
-                DiscordGuildId = discordGuildId,
-                GroupId = registered.GroupId,
-                IsActive = true,
-                CreatedAt = DateTime.UtcNow,
-            });
-        }
-
-        await db.SaveChangesAsync();
-        logger.LogInformation("Registered guild {GuildName} ({GuildId}) → Group {GroupId}", guildName, discordGuildId, registered.GroupId);
     }
 }
 
@@ -96,7 +53,7 @@ public class GuildDeleteHandler(
         {
             await using var scope = scopeFactory.CreateAsyncScope();
             var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
-            var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+            var registrationService = scope.ServiceProvider.GetRequiredService<GuildRegistrationService>();
 
             var mapping = await db.GuildMappings
                 .FirstOrDefaultAsync(m => m.DiscordGuildId == args.GuildId);
@@ -107,12 +64,7 @@ public class GuildDeleteHandler(
                 return;
             }
 
-            mapping.IsActive = false;
-            mapping.DeactivatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
-
-            await bus.PublishAsync(new UpdateGroupSharing(mapping.GroupId, false));
-            logger.LogInformation("Deactivated guild mapping for guild ({GuildId})", args.GuildId);
+            await registrationService.DeactivateAsync(mapping);
         }
         catch (Exception ex)
         {
@@ -143,7 +95,7 @@ public class ReadyHandler(
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
-        var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        var registrationService = scope.ServiceProvider.GetRequiredService<GuildRegistrationService>();
 
         var connectedGuildIds = client.Cache.Guilds.Keys.ToHashSet();
         logger.LogInformation("Guild sync: {ConnectedCount} connected guild(s), checking mappings...", connectedGuildIds.Count);
@@ -151,71 +103,20 @@ public class ReadyHandler(
         var mappedGuildIds = allMappings.ToDictionary(m => m.DiscordGuildId);
         logger.LogInformation("Guild sync: {MappedCount} existing mapping(s)", allMappings.Count);
 
-        // Register guilds the bot is in but has no mapping for
+        // Register guilds the bot is in but has no mapping for, or reactivate inactive ones
         foreach (var (guildId, guild) in client.Cache.Guilds)
         {
             if (mappedGuildIds.TryGetValue(guildId, out var mapping))
             {
                 if (!mapping.IsActive)
                 {
-                    mapping.IsActive = true;
-                    mapping.DeactivatedAt = null;
-
-                    if (mapping.PostChannelId is not null)
-                    {
-                        await bus.PublishAsync(new UpdateGroupSharing(mapping.GroupId, true));
-                    }
-
-                    logger.LogInformation("Reactivated guild mapping during sync for {GuildName} ({GuildId})", guild.Name, guildId);
+                    await registrationService.ReactivateAsync(mapping);
                 }
             }
             else
             {
-                await RegisterNewGuildAsync(guildId, guild.Name, db, bus);
+                await registrationService.RegisterGuildAsync(guildId, guild.Name);
             }
         }
-
-        // Deactivate mappings for guilds the bot is no longer in
-        foreach (var mapping in allMappings.Where(m => m.IsActive && !connectedGuildIds.Contains(m.DiscordGuildId)))
-        {
-            mapping.IsActive = false;
-            mapping.DeactivatedAt = DateTime.UtcNow;
-            await bus.PublishAsync(new UpdateGroupSharing(mapping.GroupId, false));
-            logger.LogInformation("Deactivated orphaned guild mapping for DiscordGuildId {GuildId}", mapping.DiscordGuildId);
-        }
-
-        await db.SaveChangesAsync();
-    }
-
-    private async Task RegisterNewGuildAsync(ulong discordGuildId, string guildName, BotDbContext db, IMessageBus bus)
-    {
-        logger.LogInformation("Registering guild {GuildName} ({GuildId}) via NATS...", guildName, discordGuildId);
-        var registered = await bus.InvokeAsync<CommunityRegistered>(
-            new RegisterCommunity(Providers.Discord, discordGuildId.ToString(), guildName),
-            timeout: TimeSpan.FromSeconds(10));
-
-        var existing = await db.GuildMappings
-            .FirstOrDefaultAsync(m => m.DiscordGuildId == discordGuildId);
-
-        if (existing is not null)
-        {
-            existing.GroupId = registered.GroupId;
-            existing.IsActive = true;
-            existing.DeactivatedAt = null;
-        }
-        else
-        {
-            db.GuildMappings.Add(new GuildMappingEntity
-            {
-                Id = Guid.NewGuid(),
-                DiscordGuildId = discordGuildId,
-                GroupId = registered.GroupId,
-                IsActive = true,
-                CreatedAt = DateTime.UtcNow,
-            });
-        }
-
-        await db.SaveChangesAsync();
-        logger.LogInformation("Registered guild {GuildName} ({GuildId}) → Group {GroupId}", guildName, discordGuildId, registered.GroupId);
     }
 }

--- a/src/Hermod.Bot/Services/GuildEventService.cs
+++ b/src/Hermod.Bot/Services/GuildEventService.cs
@@ -97,8 +97,7 @@ public class ReadyHandler(
         var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
         var registrationService = scope.ServiceProvider.GetRequiredService<GuildRegistrationService>();
 
-        var connectedGuildIds = client.Cache.Guilds.Keys.ToHashSet();
-        logger.LogInformation("Guild sync: {ConnectedCount} connected guild(s), checking mappings...", connectedGuildIds.Count);
+        logger.LogInformation("Guild sync: {ConnectedCount} connected guild(s), checking mappings...", client.Cache.Guilds.Count);
         var allMappings = await db.GuildMappings.ToListAsync();
         var mappedGuildIds = allMappings.ToDictionary(m => m.DiscordGuildId);
         logger.LogInformation("Guild sync: {MappedCount} existing mapping(s)", allMappings.Count);

--- a/src/Hermod.Bot/Services/GuildRegistrationService.cs
+++ b/src/Hermod.Bot/Services/GuildRegistrationService.cs
@@ -11,7 +11,7 @@ public class GuildRegistrationService(
     IMessageBus bus,
     ILogger<GuildRegistrationService> logger)
 {
-    public async Task<GuildMappingEntity> RegisterGuildAsync(ulong discordGuildId, string guildName)
+    public async Task RegisterGuildAsync(ulong discordGuildId, string guildName)
     {
         logger.LogInformation("Registering guild {GuildName} ({GuildId}) via NATS...", guildName, discordGuildId);
 
@@ -30,21 +30,18 @@ public class GuildRegistrationService(
         }
         else
         {
-            existing = new GuildMappingEntity
+            db.GuildMappings.Add(new GuildMappingEntity
             {
                 Id = Guid.NewGuid(),
                 DiscordGuildId = discordGuildId,
                 GroupId = registered.GroupId,
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
-            };
-            db.GuildMappings.Add(existing);
+            });
         }
 
         await db.SaveChangesAsync();
         logger.LogInformation("Registered guild {GuildName} ({GuildId}) → Group {GroupId}", guildName, discordGuildId, registered.GroupId);
-
-        return existing;
     }
 
     public async Task ReactivateAsync(GuildMappingEntity mapping)

--- a/src/Hermod.Bot/Services/GuildRegistrationService.cs
+++ b/src/Hermod.Bot/Services/GuildRegistrationService.cs
@@ -1,0 +1,74 @@
+using Hermod.Bot.Data;
+using Hermod.Messages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Wolverine;
+
+namespace Hermod.Bot.Services;
+
+public class GuildRegistrationService(
+    BotDbContext db,
+    IMessageBus bus,
+    ILogger<GuildRegistrationService> logger)
+{
+    public async Task<GuildMappingEntity> RegisterGuildAsync(ulong discordGuildId, string guildName)
+    {
+        logger.LogInformation("Registering guild {GuildName} ({GuildId}) via NATS...", guildName, discordGuildId);
+
+        var registered = await bus.InvokeAsync<CommunityRegistered>(
+            new RegisterCommunity(Providers.Discord, discordGuildId.ToString(), guildName),
+            timeout: TimeSpan.FromSeconds(10));
+
+        var existing = await db.GuildMappings
+            .FirstOrDefaultAsync(m => m.DiscordGuildId == discordGuildId);
+
+        if (existing is not null)
+        {
+            existing.GroupId = registered.GroupId;
+            existing.IsActive = true;
+            existing.DeactivatedAt = null;
+        }
+        else
+        {
+            existing = new GuildMappingEntity
+            {
+                Id = Guid.NewGuid(),
+                DiscordGuildId = discordGuildId,
+                GroupId = registered.GroupId,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+            };
+            db.GuildMappings.Add(existing);
+        }
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Registered guild {GuildName} ({GuildId}) → Group {GroupId}", guildName, discordGuildId, registered.GroupId);
+
+        return existing;
+    }
+
+    public async Task ReactivateAsync(GuildMappingEntity mapping)
+    {
+        mapping.IsActive = true;
+        mapping.DeactivatedAt = null;
+        await db.SaveChangesAsync();
+
+        if (mapping.PostChannelId is not null)
+        {
+            await bus.PublishAsync(new UpdateGroupSharing(mapping.GroupId, true));
+        }
+
+        logger.LogInformation("Reactivated guild mapping for DiscordGuildId {GuildId} → Group {GroupId}", mapping.DiscordGuildId, mapping.GroupId);
+    }
+
+    public async Task DeactivateAsync(GuildMappingEntity mapping)
+    {
+        mapping.IsActive = false;
+        mapping.DeactivatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+
+        await bus.PublishAsync(new UpdateGroupSharing(mapping.GroupId, false));
+
+        logger.LogInformation("Deactivated guild mapping for DiscordGuildId {GuildId}", mapping.DiscordGuildId);
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix startup race condition**: `ReadyHandler.SyncGuildsAsync` raced against Discord's guild cache population, deactivating guilds that hadn't loaded yet. This caused intermittent "This server hasn't been set up yet" errors on `/enroll`. The sync is now additive-only — it registers missing guilds and reactivates inactive ones, but never deactivates.
- **Add `/sharing activate` and `/sharing deactivate`**: Server admins (ManageGuild permission) can now manually control their guild's registration state. Deactivation only happens via explicit bot removal (`GuildDeleteHandler`) or this new command.
- **Extract `GuildRegistrationService`**: Deduplicates `RegisterNewGuildAsync` (was copy-pasted between `GuildCreateHandler` and `ReadyHandler`) into a shared scoped service with `RegisterGuildAsync`, `ReactivateAsync`, and `DeactivateAsync` methods.

## Test plan

- [x] Solution builds clean (0 warnings, 0 errors)
- [x] All non-BGStats tests pass (Bot, Api 147, E2E 3 — BGStats failures are pre-existing missing sample files in worktree)
- [ ] Manual: restart bot, confirm sync no longer logs "Deactivated orphaned guild mapping"
- [ ] Manual: `/sharing activate` registers/reactivates a guild
- [ ] Manual: `/sharing deactivate` deactivates a guild, `/enroll` shows "not set up"
- [ ] Manual: `/sharing activate` after deactivate restores the guild

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)