### PR TITLE
Fix OAuth correlation failure and harden forwarded headers

### DIFF
--- a/src/Hermod.Api/Program.cs
+++ b/src/Hermod.Api/Program.cs
@@ -3,12 +3,12 @@ using Hermod.Auth;
 using Hermod.Data;
 using Hermod.Messages;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Wolverine;
 using Wolverine.EntityFrameworkCore;
 using Wolverine.ErrorHandling;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.HttpOverrides;
 using Wolverine.Http;
 using Wolverine.Nats;
 using Wolverine.Postgresql;
@@ -126,23 +126,21 @@ var forwardedHeadersOptions = new ForwardedHeadersOptions
     ForwardLimit = app.Configuration.GetValue<int?>("ForwardedHeaders:ForwardLimit"),
 };
 
+forwardedHeadersOptions.KnownIPNetworks.Clear();
+forwardedHeadersOptions.KnownProxies.Clear();
+
 var knownNetworks = app.Configuration.GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>();
 if (knownNetworks is { Length: > 0 })
 {
-    forwardedHeadersOptions.KnownIPNetworks.Clear();
-    forwardedHeadersOptions.KnownProxies.Clear();
     foreach (var cidr in knownNetworks)
     {
         var parts = cidr.Split('/');
+        if (parts.Length != 2)
+            throw new InvalidOperationException($"Invalid CIDR notation '{cidr}' in ForwardedHeaders:KnownNetworks. Expected format: '10.42.0.0/16'.");
+
         forwardedHeadersOptions.KnownIPNetworks.Add(
             new System.Net.IPNetwork(System.Net.IPAddress.Parse(parts[0]), int.Parse(parts[1])));
     }
-}
-else
-{
-    // Development: trust all sources (no CIDR restriction)
-    forwardedHeadersOptions.KnownIPNetworks.Clear();
-    forwardedHeadersOptions.KnownProxies.Clear();
 }
 
 app.UseForwardedHeaders(forwardedHeadersOptions);

--- a/src/Hermod.Api/Program.cs
+++ b/src/Hermod.Api/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Wolverine;
 using Wolverine.EntityFrameworkCore;
 using Wolverine.ErrorHandling;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Wolverine.Http;
 using Wolverine.Nats;
@@ -39,6 +40,10 @@ builder.EnrichNpgsqlDbContext<HermodContext>(settings =>
 
 builder.AddNpgsqlDbContext<AuthDbContext>("auth-db");
 
+builder.Services.AddDataProtection()
+    .SetApplicationName("hermod-api")
+    .PersistKeysToDbContext<AuthDbContext>();
+
 builder.Services.AddScoped<ExternalLoginService>();
 builder.Services.AddScoped<IExternalUserResolver, ExternalUserResolver>();
 
@@ -69,6 +74,8 @@ builder.Services.AddAuthentication(options =>
         ?? throw new InvalidOperationException("Discord:ClientSecret is not configured.");
     options.CallbackPath = "/signin-discord";
     options.SaveTokens = false;
+    options.CorrelationCookie.SameSite = SameSiteMode.Lax;
+    options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
     options.Events.OnCreatingTicket = DiscordOAuthEvents.OnCreatingTicket;
 });
 
@@ -113,11 +120,31 @@ var app = builder.Build();
 
 var forwardedHeadersOptions = new ForwardedHeadersOptions
 {
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
-    ForwardLimit = null, // Allow multiple proxy hops (e.g. tunnel → YARP → Vite → API)
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor
+        | ForwardedHeaders.XForwardedProto
+        | ForwardedHeaders.XForwardedHost,
+    ForwardLimit = app.Configuration.GetValue<int?>("ForwardedHeaders:ForwardLimit"),
 };
-forwardedHeadersOptions.KnownIPNetworks.Clear();
-forwardedHeadersOptions.KnownProxies.Clear();
+
+var knownNetworks = app.Configuration.GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>();
+if (knownNetworks is { Length: > 0 })
+{
+    forwardedHeadersOptions.KnownIPNetworks.Clear();
+    forwardedHeadersOptions.KnownProxies.Clear();
+    foreach (var cidr in knownNetworks)
+    {
+        var parts = cidr.Split('/');
+        forwardedHeadersOptions.KnownIPNetworks.Add(
+            new System.Net.IPNetwork(System.Net.IPAddress.Parse(parts[0]), int.Parse(parts[1])));
+    }
+}
+else
+{
+    // Development: trust all sources (no CIDR restriction)
+    forwardedHeadersOptions.KnownIPNetworks.Clear();
+    forwardedHeadersOptions.KnownProxies.Clear();
+}
+
 app.UseForwardedHeaders(forwardedHeadersOptions);
 
 // When behind a dev tunnel, the YARP container overwrites X-Forwarded-Host

--- a/src/Hermod.Auth/AuthDbContext.cs
+++ b/src/Hermod.Auth/AuthDbContext.cs
@@ -1,11 +1,13 @@
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Hermod.Auth;
 
-public class AuthDbContext(DbContextOptions<AuthDbContext> options) : DbContext(options)
+public class AuthDbContext(DbContextOptions<AuthDbContext> options) : DbContext(options), IDataProtectionKeyContext
 {
     public DbSet<AuthUser> Users => Set<AuthUser>();
     public DbSet<ExternalLogin> ExternalLogins => Set<ExternalLogin>();
+    public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Hermod.Auth/Hermod.Auth.csproj
+++ b/src/Hermod.Auth/Hermod.Auth.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />

--- a/src/Hermod.Auth/Migrations/20260310033108_AddDataProtectionKeys.Designer.cs
+++ b/src/Hermod.Auth/Migrations/20260310033108_AddDataProtectionKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hermod.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hermod.Auth.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310033108_AddDataProtectionKeys")]
+    partial class AddDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Hermod.Auth/Migrations/20260310033108_AddDataProtectionKeys.cs
+++ b/src/Hermod.Auth/Migrations/20260310033108_AddDataProtectionKeys.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Hermod.Auth.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #63

- **Align correlation cookie** with session cookie (`SameSite=Lax`, `SecurePolicy=SameAsRequest`) — the default `SameSite=None` + `Secure=Always` caused the browser to drop the cookie when any proxy hop presented as HTTP
- **Persist Data Protection keys** to auth-db via `PersistKeysToDbContext<AuthDbContext>()` — ephemeral in-memory keys were lost on pod restart, making the correlation cookie undecryptable (likely cause of intermittent nature)
- **Make ForwardedHeaders config-driven** — `ForwardLimit` and `KnownNetworks` are now read from configuration, defaulting to permissive (dev) when unset

## Deployment changes (home-ops)

Add these environment variables to the `hermod-api` deployment:

```yaml
# ForwardedHeaders scoping
- name: ForwardedHeaders__ForwardLimit
  value: "3"                          # Cloudflare → Envoy → YARP
- name: ForwardedHeaders__KnownNetworks__0
  value: "10.42.0.0/16"              # k3s cluster CIDR (matches Envoy ClientTrafficPolicy)
```

**Notes:**
- `DataProtectionKeys` table is created automatically by EF migration on first startup — no manual DB work
- All existing user sessions will be invalidated on first deploy (ephemeral keys replaced by persistent ones) — users re-login once
- No new secrets or volumes needed — keys stored in existing `auth-db` PostgreSQL database
- Rollback safe — same one-time re-login impact in either direction

## Test plan

- [x] `dotnet build Hermod.slnx` — 0 errors, 0 warnings
- [x] `dotnet test --solution Hermod.slnx` — 97 API tests pass (auth tests apply new migration)
- [ ] `aspire run` → Discord login → verify no correlation failure; confirm `DataProtectionKeys` table has a row in auth-db

🤖 Generated with [Claude Code](https://claude.com/claude-code)